### PR TITLE
Fix streaming issues and improve chat UI styling

### DIFF
--- a/src/vs/workbench/contrib/alphacode/browser/vibeCodingView.ts
+++ b/src/vs/workbench/contrib/alphacode/browser/vibeCodingView.ts
@@ -1130,14 +1130,24 @@ export class VibeCodingView extends ViewPane {
 	}
 
 	private removeToolBlocksForStreaming(content: string): string {
-		// Remplacer les blocs tool par un indicateur visuel pendant le streaming
-		return content.replace(/```tool\s*\n[\s\S]*?\n```/g, '🔧 _[Tool execution]_');
+		// Remplacer les blocs tool par un message de chargement pendant l'exécution
+		// Le vrai contenu sera affiché une fois le tool terminé
+		return content.replace(/```tool\s*\n([\s\S]*?)\n```/g, (match, toolJson) => {
+			try {
+				const tool = JSON.parse(toolJson);
+				const toolName = tool.name || 'Tool';
+				// Message de chargement simple et discret
+				return `_Executing ${toolName}..._`;
+			} catch {
+				return '_Loading..._';
+			}
+		});
 	}
 
 	private renderStreamingBuffer(): void {
 		if (!this.currentStreamingMessage) return;
 
-		// Nettoyer le contenu pour l'affichage
+		// Nettoyer le contenu pour l'affichage en streaming
 		const cleanContent = this.removeToolBlocksForStreaming(this.currentStreamingBuffer);
 		if (cleanContent === this.lastRenderedStreamingContent) return;
 


### PR DESCRIPTION
Fixes:
- Fix streaming stopping automatically when write tools are detected
- Fix tool display during streaming (show "Executing..." instead of raw tool blocks)
- Fix diff stats counter to support both "insertion/deletion" and "lines added/removed" formats

UI Improvements:
- Adopt minimalist Claude Code style for chat interface
- Hide avatars and headers for cleaner look
- Simplify tool display (Read, Searched, etc.) to plain gray text
- Style code references in blue with clickable links
- Auto-detect file references (filename.ts:42) and language badges (TS, JS)
- Display diff stats (+428 -425) in green/red for file edits
- Reduce spacing between messages for compact view
- Remove backgrounds, borders, and shadows for minimalist aesthetic

Technical changes:
- streamHandler.ts: Remove premature done signal on write tool detection
- vibeCodingView.ts: Update tool rendering and streaming buffer display
- markdownRenderer.ts: Add auto-detection for file refs and language badges
- chatView.css: Complete style overhaul for minimalist design

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
